### PR TITLE
Add Node test for calculateTeenData

### DIFF
--- a/calculateTeenData.js
+++ b/calculateTeenData.js
@@ -1,0 +1,26 @@
+function calculateTeenData(data) {
+  const today = new Date();
+  const currentYear = today.getFullYear();
+  const currentMonth = today.getMonth(); // 0 = January, 11 = December
+  let currentGrade = currentYear - data.gradYear + 12;
+
+  if (currentGrade > 12 || (currentGrade === 12 && currentMonth >= 6)) {
+    currentGrade = "Graduated";
+  }
+
+  let confirmationYear = currentYear;
+  if (currentMonth >= 6) {
+    // After June (July to December)
+    confirmationYear += 12 - parseInt(data.confirmationLevel);
+  } else {
+    confirmationYear += 11 - parseInt(data.confirmationLevel);
+  }
+
+  return {
+    ...data,
+    currentGrade,
+    confirmationYear,
+  };
+}
+
+module.exports = calculateTeenData;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "journey-sign-in",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node test/calculateTeenData.test.js"
+  }
+}

--- a/test/calculateTeenData.test.js
+++ b/test/calculateTeenData.test.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+const calculateTeenData = require('../calculateTeenData');
+
+// Helper to mock the current date during the test
+function withMockedDate(isoDate, fn) {
+  const RealDate = Date;
+  global.Date = class extends RealDate {
+    constructor(...args) {
+      if (args.length === 0) {
+        return new RealDate(isoDate);
+      }
+      return new RealDate(...args);
+    }
+    static now() {
+      return new RealDate(isoDate).getTime();
+    }
+    static parse(str) {
+      return RealDate.parse(str);
+    }
+    static UTC(...args) {
+      return RealDate.UTC(...args);
+    }
+  };
+  try {
+    fn();
+  } finally {
+    global.Date = RealDate;
+  }
+}
+
+withMockedDate('2024-07-15T00:00:00Z', () => {
+  const sample = { gradYear: 2027, confirmationLevel: '3' };
+  const result = calculateTeenData(sample);
+
+  assert.strictEqual(result.currentGrade, 9);
+  assert.strictEqual(result.confirmationYear, 2033);
+});
+
+console.log('calculateTeenData test passed');


### PR DESCRIPTION
## Summary
- add a Node module for `calculateTeenData`
- add a simple Node test verifying `currentGrade` and `confirmationYear`
- add `package.json` with test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887b12d73c88330b11e00a1d3d76ea8